### PR TITLE
Add the "@import" compiler directive (a detailed description here: https://stoneofarc.wordpress.com/2013/06/25/introduction-to-objective-c-modules/ ).

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,6 +605,7 @@ Directive | Purpose
 @encode(spec) | Yields a character string that encodes the type structure of `spec`
 @compatibility_alias | Allows you to define an alias name for an existing class.
 @defs(classname) | Yields the internal data structure of `classname` instances
+@import | Imports a module and autolinks its framework (currently for Apple frameworks only)
 
 [Back to top](#objective-c-cheat-sheet)
 


### PR DESCRIPTION
I was surprised not to see this one... then again, it's relatively new!

I wasn't sure if it made better sense to put this in the "Classes and Protocols" section. I put it in "Other" since it's not strictly related to classes.